### PR TITLE
Rework package script for Go 1.11

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -34,24 +34,28 @@ while read -r OS ARCH; do
   TARGET_PATH="${BASEDIR}/binaries/${OS}-${ARCH}"
   mkdir -p "$TARGET_PATH"
 
-  for PKGPATH in \
-    github.com/client9/misspell/cmd/misspell \
-    github.com/fzipp/gocyclo \
-    github.com/modocache/gover \
-    github.com/onsi/ginkgo/ginkgo \
-    golang.org/x/lint/golint \
-    honnef.co/go/tools/cmd/megacheck; do
-
-    if [[ ! -d "$GOPATH/src/${PKGPATH}" ]]; then
-      go get -d "${PKGPATH}"
+  while read -r DOWNLOAD_PKG INSTALL_PKG BINARY_NAME MODULE_MODE; do
+    if [[ ! -d "$GOPATH/src/${DOWNLOAD_PKG}" ]]; then
+      GO111MODULE="${MODULE_MODE}" go get -d "${DOWNLOAD_PKG}"
     fi
 
-    VERSION=$(cd "$GOPATH/src/${PKGPATH}" && (git describe --tags 2>/dev/null || git rev-parse HEAD | cut -c-8))
+    echo -e "Building \\033[1m${INSTALL_PKG}\\033[0m for OS \\033[1;34m${OS}\\033[0m and architecture \\033[1;33m${ARCH}\\033[0m"
+    (cd "${TARGET_PATH}" &&
+      GO111MODULE="${MODULE_MODE}" GOOS="${OS}" GOARCH="${ARCH}" go build \
+        -o "${BINARY_NAME}" \
+        -tags netgo \
+        -ldflags='-s -w -extldflags "-static"' \
+        "${INSTALL_PKG}")
 
-    echo -e "Compiling \\033[1m${PKGPATH}\\033[0m version \\033[1;3m${VERSION}\\033[0m for OS \\033[1;34m${OS}\\033[0m and architecture \\033[1;33m${ARCH}\\033[0m"
-    (cd "${TARGET_PATH}" && GOOS="$OS" GOARCH="$ARCH" go build -tags netgo -ldflags='-s -w -extldflags "-static"' "${PKGPATH}")
-
-  done
+  done <<EOT
+github.com/client9/misspell github.com/client9/misspell/cmd/misspell misspell auto
+github.com/homeport/pina-golada/cmd/golada github.com/homeport/pina-golada/cmd/golada pina-golada on
+honnef.co/go/tools/cmd/staticcheck honnef.co/go/tools/cmd/staticcheck staticcheck auto
+github.com/fzipp/gocyclo github.com/fzipp/gocyclo gocyclo auto
+github.com/modocache/gover github.com/modocache/gover gover auto
+github.com/onsi/ginkgo/ginkgo github.com/onsi/ginkgo/ginkgo ginkgo auto
+golang.org/x/lint/golint golang.org/x/lint/golint golint auto
+EOT
 
   echo -e "Package binaries into tarball \\033[1;32m${OUTPUT_DIR}/golang-dev-tools-${OS}-${ARCH}.tar.gz\\033[0m"
   (cd "${TARGET_PATH}" && tar -cf - -- *) | gzip --best >"${OUTPUT_DIR}/golang-dev-tools-${OS}-${ARCH}.tar.gz"


### PR DESCRIPTION
Rework package script to use Go 1.11 modules feature to build the binaries.

Add `pina-golada` to the list of tools.

Replace `megacheck` with `staticcheck`.